### PR TITLE
Fix Core Data model loading error

### DIFF
--- a/Packages/PersistenceKit/Sources/PersistenceKit/CoreDataStack.swift
+++ b/Packages/PersistenceKit/Sources/PersistenceKit/CoreDataStack.swift
@@ -5,11 +5,28 @@ public final class CoreDataStack {
     public let persistentContainer: NSPersistentContainer
 
     private init() {
-        guard let modelURL = Bundle.main.url(forResource: "OpenLangAI", withExtension: "momd") else {
-            fatalError("Failed to find data model")
+        // First try to find the model in the framework bundle
+        let bundle = Bundle(for: CoreDataStack.self)
+        
+        // Try to find the compiled model (.momd)
+        var modelURL = bundle.url(forResource: "OpenLangAI", withExtension: "momd")
+        
+        // If not found, try the model definition (.xcdatamodeld)
+        if modelURL == nil {
+            modelURL = bundle.url(forResource: "OpenLangAI", withExtension: "xcdatamodeld")
         }
-        guard let mom = NSManagedObjectModel(contentsOf: modelURL) else {
-            fatalError("Failed to create model from file: \(modelURL)")
+        
+        // If still not found, try Bundle.main as a fallback
+        if modelURL == nil {
+            modelURL = Bundle.main.url(forResource: "OpenLangAI", withExtension: "momd")
+        }
+        
+        guard let finalModelURL = modelURL else {
+            fatalError("Failed to find data model in bundle: \(bundle)")
+        }
+        
+        guard let mom = NSManagedObjectModel(contentsOf: finalModelURL) else {
+            fatalError("Failed to create model from file: \(finalModelURL)")
         }
         
         persistentContainer = NSPersistentCloudKitContainer(name: "OpenLangAI", managedObjectModel: mom)

--- a/Packages/PersistenceKit/Sources/PersistenceKit/PersistenceController.swift
+++ b/Packages/PersistenceKit/Sources/PersistenceKit/PersistenceController.swift
@@ -12,11 +12,28 @@ public class PersistenceController {
     
     private init() {
         // Load the Core Data model from Bundle.main
-        guard let modelURL = Bundle.main.url(forResource: "OpenLangAI", withExtension: "momd") else {
-            fatalError("Failed to find data model")
+        // First try to find the model in the framework bundle
+        let bundle = Bundle(for: PersistenceController.self)
+        
+        // Try to find the compiled model (.momd)
+        var modelURL = bundle.url(forResource: "OpenLangAI", withExtension: "momd")
+        
+        // If not found, try the model definition (.xcdatamodeld)
+        if modelURL == nil {
+            modelURL = bundle.url(forResource: "OpenLangAI", withExtension: "xcdatamodeld")
         }
-        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
-            fatalError("Failed to create model from file: \(modelURL)")
+        
+        // If still not found, try Bundle.main as a fallback
+        if modelURL == nil {
+            modelURL = Bundle.main.url(forResource: "OpenLangAI", withExtension: "momd")
+        }
+        
+        guard let finalModelURL = modelURL else {
+            fatalError("Failed to find data model in bundle: \(bundle)")
+        }
+        
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: finalModelURL) else {
+            fatalError("Failed to create model from file: \(finalModelURL)")
         }
         
         container = NSPersistentCloudKitContainer(name: "OpenLangAI", managedObjectModel: managedObjectModel)


### PR DESCRIPTION
## Summary
Fixes runtime crash "Failed to find data model" when running on iPhone device.

## Problem
The app was crashing because CoreDataStack and PersistenceController were looking for the Core Data model in Bundle.main, but since PersistenceKit is a framework, the model is actually in the framework's bundle.

## Solution
Updated both CoreDataStack and PersistenceController to:
1. First look for the model in the framework bundle
2. Try both .momd (compiled) and .xcdatamodeld (source) extensions  
3. Fall back to Bundle.main as a last resort

## Test plan
[x] Build and run on iPhone 16 Pro (iOS 18.5)
[x] Verify app launches without crashing
[x] Confirm Core Data operations work correctly

## Technical Details
- Uses `Bundle(for: Type.self)` to get the correct framework bundle
- Checks multiple locations to handle different build configurations
- Provides clear error messages if model still can't be found

🤖 Generated with [Claude Code](https://claude.ai/code)